### PR TITLE
Реализация задач ТЗ спринта 6

### DIFF
--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -6,15 +6,56 @@ import service.*;
 public class Main {
     public static void main(String[] args) {
         TaskManager manager = Managers.getDefault();
-        Task task = new Task("Задача", "Описание задачи", Status.NEW);
-        Epic epic = new Epic("Эпик", "Описание эпика");
-        SubTask subTask = new SubTask("Подзадача", "Описание подзадачи",
-                Status.DONE, 2);
 
-        manager.createTask(task);
-        manager.createEpic(epic);
-        manager.createSubTask(subTask);
-        printAllTasks(manager);
+        Task taskA = new Task("Задача A", "Описание задачи A", Status.NEW);
+        Task taskB = new Task("Задача B", "Описание задачи B", Status.DONE);
+        Epic epicA = new Epic("Эпик A", "Описание эпика с тремя подзадачами");
+        Epic epicB = new Epic("Эпик B", "Описание эпика без подзадач");
+        SubTask subTaskA = new SubTask("Подзадача A1", "Подзадача 1 эпика A",
+                Status.NEW, 3);
+        SubTask subTaskB = new SubTask("Подзадача A2", "Подзадача 2 эпика A",
+                Status.DONE, 3);
+        SubTask subTaskC = new SubTask("Подзадача A3", "Подзадача 3 эпика A",
+                Status.NEW, 3);
+
+        manager.createTask(taskA); // id = 1
+        manager.createTask(taskB); // id = 2
+        manager.createEpic(epicA); // id = 3
+        manager.createEpic(epicB); // id = 4
+        manager.createSubTask(subTaskA); // id = 5
+        manager.createSubTask(subTaskB); // id = 6
+        manager.createSubTask(subTaskC); // id = 7
+
+        manager.getTaskById(2);
+        System.out.println(manager.getHistory());
+
+        manager.getEpicById(4);
+        System.out.println(manager.getHistory());
+
+        manager.getSubTaskById(6);
+        System.out.println(manager.getHistory());
+
+        manager.getTaskById(2);
+        System.out.println(manager.getHistory());
+
+        manager.getSubTaskById(7);
+        System.out.println(manager.getHistory());
+
+        manager.getSubTaskById(6);
+        System.out.println(manager.getHistory());
+
+        manager.getTaskById(2);
+        System.out.println(manager.getHistory());
+
+        manager.getEpicById(4);
+        System.out.println(manager.getHistory());
+
+        manager.removeTaskById(2);
+        System.out.println(manager.getHistory());
+
+        manager.removeEpicById(3);
+        System.out.println(manager.getHistory());
+
     }
 
     private static void printAllTasks(TaskManager manager) {

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -5,26 +5,7 @@ import service.*;
 
 public class Main {
     public static void main(String[] args) {
-        TaskManager manager = Managers.getDefault();
-
-        Task taskA = new Task("Задача A", "Описание задачи A", Status.NEW);
-        Task taskB = new Task("Задача B", "Описание задачи B", Status.DONE);
-        Epic epicA = new Epic("Эпик A", "Описание эпика с тремя подзадачами");
-        Epic epicB = new Epic("Эпик B", "Описание эпика без подзадач");
-        SubTask subTaskA = new SubTask("Подзадача A1", "Подзадача 1 эпика A",
-                Status.NEW, 3);
-        SubTask subTaskB = new SubTask("Подзадача A2", "Подзадача 2 эпика A",
-                Status.DONE, 3);
-        SubTask subTaskC = new SubTask("Подзадача A3", "Подзадача 3 эпика A",
-                Status.NEW, 3);
-
-        manager.createTask(taskA); // id = 1
-        manager.createTask(taskB); // id = 2
-        manager.createEpic(epicA); // id = 3
-        manager.createEpic(epicB); // id = 4
-        manager.createSubTask(subTaskA); // id = 5
-        manager.createSubTask(subTaskB); // id = 6
-        manager.createSubTask(subTaskC); // id = 7
+        TaskManager manager = getTaskManager();
 
         manager.getTaskById(2);
         System.out.println(manager.getHistory());
@@ -56,6 +37,30 @@ public class Main {
         manager.removeEpicById(3);
         System.out.println(manager.getHistory());
 
+    }
+
+    private static TaskManager getTaskManager() {
+        TaskManager manager = Managers.getDefault();
+
+        Task taskA = new Task("Задача A", "Описание задачи A", Status.NEW);
+        Task taskB = new Task("Задача B", "Описание задачи B", Status.DONE);
+        Epic epicA = new Epic("Эпик A", "Описание эпика с тремя подзадачами");
+        Epic epicB = new Epic("Эпик B", "Описание эпика без подзадач");
+        SubTask subTaskA = new SubTask("Подзадача A1", "Подзадача 1 эпика A",
+                Status.NEW, 3);
+        SubTask subTaskB = new SubTask("Подзадача A2", "Подзадача 2 эпика A",
+                Status.DONE, 3);
+        SubTask subTaskC = new SubTask("Подзадача A3", "Подзадача 3 эпика A",
+                Status.NEW, 3);
+
+        manager.createTask(taskA); // id = 1
+        manager.createTask(taskB); // id = 2
+        manager.createEpic(epicA); // id = 3
+        manager.createEpic(epicB); // id = 4
+        manager.createSubTask(subTaskA); // id = 5
+        manager.createSubTask(subTaskB); // id = 6
+        manager.createSubTask(subTaskC); // id = 7
+        return manager;
     }
 
     private static void printAllTasks(TaskManager manager) {

--- a/src/model/Epic.java
+++ b/src/model/Epic.java
@@ -82,12 +82,6 @@ public class Epic extends Task {
     }
 
     @Override
-    public void setStatus(Status status) {
-        System.out.println("Ошибка изменения статуса: "
-                + "для эпиков ручное изменение статуса запрещено");
-    }
-
-    @Override
     public String toString() {
         return "Epic{" +
                 "subTaskIdList=" + getSubTaskIdList() +

--- a/src/model/Node.java
+++ b/src/model/Node.java
@@ -17,21 +17,13 @@ public class Node<T> {
 
         if (next != null) {
             nextNode = next;
-            nextNode.linkPrev(prev);
+            nextNode.prev = prev;
         }
 
         if (prev != null) {
             prevNode = prev;
-            prevNode.linkNext(next);
+            prevNode.next = next;
         }
-    }
-
-    public void linkNext(Node<T> node) {
-        next = node;
-    }
-
-    public void linkPrev(Node<T> node) {
-        prev = node;
     }
 
     @Override

--- a/src/model/Node.java
+++ b/src/model/Node.java
@@ -3,9 +3,9 @@ package model;
 import java.util.Objects;
 
 public class Node<T> {
-    Node<T> next;
-    Node<T> prev;
-    T value;
+    public Node<T> next;
+    public Node<T> prev;
+    public T value;
 
     public Node(T value) {
         this.value = value;

--- a/src/model/Node.java
+++ b/src/model/Node.java
@@ -1,0 +1,56 @@
+package model;
+
+import java.util.Objects;
+
+public class Node<T> {
+    Node<T> next;
+    Node<T> prev;
+    T value;
+
+    public Node(T value) {
+        this.value = value;
+    }
+
+    public void removeSelf() {
+        Node<T> prevNode;
+        Node<T> nextNode;
+
+        if (next != null) {
+            nextNode = next;
+            nextNode.linkPrev(prev);
+        }
+
+        if (prev != null) {
+            prevNode = prev;
+            prevNode.linkNext(next);
+        }
+    }
+
+    public void linkNext(Node<T> node) {
+        next = node;
+    }
+
+    public void linkPrev(Node<T> node) {
+        prev = node;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        Node<?> node = (Node<?>) object;
+        return Objects.equals(next, node.next) && Objects.equals(prev, node.prev) && Objects.equals(value, node.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(next, prev, value);
+    }
+
+    @Override
+    public String toString() {
+        return "Node{" +
+                "value=" + value +
+                '}';
+    }
+}

--- a/src/model/Task.java
+++ b/src/model/Task.java
@@ -3,10 +3,10 @@ package model;
 import java.util.Objects;
 
 public class Task {
-    private int id;
     private final String title;
     private final String description;
     private final Status status;
+    private int id;
 
     public Task(String title, String description, Status status) {
         this.title = title;

--- a/src/model/Task.java
+++ b/src/model/Task.java
@@ -4,9 +4,9 @@ import java.util.Objects;
 
 public class Task {
     private int id;
-    private String title;
-    private String description;
-    private Status status;
+    private final String title;
+    private final String description;
+    private final Status status;
 
     public Task(String title, String description, Status status) {
         this.title = title;
@@ -26,24 +26,12 @@ public class Task {
         return title;
     }
 
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
     public String getDescription() {
         return description;
     }
 
-    public void setDescription(String description){
-        this.description = description;
-    }
-
     public Status getStatus() {
         return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
     }
 
     @Override

--- a/src/service/HistoryManager.java
+++ b/src/service/HistoryManager.java
@@ -8,6 +8,4 @@ public interface HistoryManager {
     void addTask(Task task);
 
     Deque<Task> getHistory();
-
-    int getHistoryMaxSize();
 }

--- a/src/service/HistoryManager.java
+++ b/src/service/HistoryManager.java
@@ -2,10 +2,12 @@ package service;
 
 import model.Task;
 
-import java.util.Deque;
+import java.util.List;
 
 public interface HistoryManager {
     void addTask(Task task);
 
-    Deque<Task> getHistory();
+    List<Task> getHistory();
+
+    void remove(int id);
 }

--- a/src/service/IdGenerator.java
+++ b/src/service/IdGenerator.java
@@ -3,7 +3,7 @@ package service;
 public class IdGenerator {
     private int id = 1;
 
-    public int generateId(){
+    public int generateId() {
         return id++;
     }
 }

--- a/src/service/InMemoryHistoryManager.java
+++ b/src/service/InMemoryHistoryManager.java
@@ -1,20 +1,53 @@
 package service;
 
+import model.Node;
 import model.Task;
 
 import java.util.*;
 
 public class InMemoryHistoryManager implements HistoryManager {
-    private final Deque<Task> viewsHistory = new LinkedList<>();
+    private final Map<Integer, Node<Task>> historyMap = new HashMap<>();
+    private Node<Task> head;
+    private Node<Task> tail;
+
+    private void linkLast(Node<Task> node) {
+        if (tail == null) {
+            head = node;
+        } else {
+            tail.next = node;
+            node.prev = tail;
+        }
+        tail = node;
+    }
+
+    public void remove(int taskId) {
+        historyMap.get(taskId).removeSelf();
+    }
 
     @Override
-    public Deque<Task> getHistory() {
-        return viewsHistory;
+    public List<Task> getHistory() {
+        List<Task> history = new ArrayList<>();
+        Node<Task> pointer = head;
+
+        while (pointer != null) {
+            history.add(pointer.value);
+            pointer = pointer.next;
+        }
+
+        return history;
     }
 
     @Override
     public void addTask(Task task) {
-        viewsHistory.addLast(task);
+        Integer taskId = task.getId();
+
+        if (historyMap.containsKey(taskId)) {
+            remove(taskId);
+        }
+
+        Node<Task> newHistoryRecord = new Node<>(task);
+        historyMap.put(taskId, newHistoryRecord);
+        linkLast(newHistoryRecord);
     }
 
 }

--- a/src/service/InMemoryHistoryManager.java
+++ b/src/service/InMemoryHistoryManager.java
@@ -6,7 +6,6 @@ import java.util.*;
 
 public class InMemoryHistoryManager implements HistoryManager {
     private final Deque<Task> viewsHistory = new LinkedList<>();
-    private final int HISTORY_MAX_SIZE = 10;
 
     @Override
     public Deque<Task> getHistory() {
@@ -15,15 +14,7 @@ public class InMemoryHistoryManager implements HistoryManager {
 
     @Override
     public void addTask(Task task) {
-        if (viewsHistory.size() >= HISTORY_MAX_SIZE) {
-            viewsHistory.removeFirst();
-        }
         viewsHistory.addLast(task);
-    }
-
-    @Override
-    public int getHistoryMaxSize() {
-        return HISTORY_MAX_SIZE;
     }
 
 }

--- a/src/service/InMemoryHistoryManager.java
+++ b/src/service/InMemoryHistoryManager.java
@@ -21,6 +21,23 @@ public class InMemoryHistoryManager implements HistoryManager {
     }
 
     public void remove(int taskId) {
+        if (taskId == tail.value.getId()) {
+            if (tail.prev != null) {
+                tail = tail.prev;
+                tail.next = null;
+            } else {
+                tail = null;
+            }
+            return;
+        } else if (taskId == head.value.getId()) {
+            if (head.next != null) {
+                head = head.next;
+                head.prev = null;
+            } else {
+                head = null;
+            }
+            return;
+        }
         historyMap.get(taskId).removeSelf();
     }
 

--- a/src/service/InMemoryHistoryManager.java
+++ b/src/service/InMemoryHistoryManager.java
@@ -38,7 +38,9 @@ public class InMemoryHistoryManager implements HistoryManager {
             }
             return;
         }
-        historyMap.get(taskId).removeSelf();
+        if (historyMap.containsKey(taskId)) {
+            historyMap.remove(taskId).removeSelf();
+        }
     }
 
     @Override

--- a/src/service/InMemoryTaskManager.java
+++ b/src/service/InMemoryTaskManager.java
@@ -25,7 +25,7 @@ public class InMemoryTaskManager implements TaskManager {
     }
 
     @Override
-    public Deque<Task> getHistory() {
+    public List<Task> getHistory() {
         return historyManager.getHistory();
     }
 

--- a/src/service/InMemoryTaskManager.java
+++ b/src/service/InMemoryTaskManager.java
@@ -188,6 +188,7 @@ public class InMemoryTaskManager implements TaskManager {
     public void removeTaskById(int id) {
         if (allTasks.containsKey(id)) {
             allTasks.remove(id);
+            historyManager.remove(id);
         } else {
             System.out.println("Ошибка при вызове removeTaskById(int id): Невозможно удалить задачу id "
                     + id + " по id: задача не найдена.");
@@ -204,6 +205,7 @@ public class InMemoryTaskManager implements TaskManager {
                 removeSubTaskById(subTaskId);
             }
             allEpics.remove(id);
+            historyManager.remove(id);
         } else {
             throw new IllegalArgumentException("Ошибка при вызове removeEpicById(int id): Невозможно удалить эпик id "
                     + id + " по id - эпик не найден.");
@@ -218,6 +220,7 @@ public class InMemoryTaskManager implements TaskManager {
 
             epic.unlinkSubTask(id);
             allSubTasks.remove(id);
+            historyManager.remove(id);
         } else {
             System.out.println("Ошибка при вызове removeSubTaskById(int id): Невозможно удалить подзадачу id "
                     + id + " по id: подзадача не найдена.");

--- a/src/service/TaskManager.java
+++ b/src/service/TaskManager.java
@@ -5,7 +5,7 @@ import model.*;
 import java.util.*;
 
 public interface TaskManager {
-    Deque<Task> getHistory();
+    List<Task> getHistory();
 
     List<Task> getTasks();
 

--- a/test/model/NodeTest.java
+++ b/test/model/NodeTest.java
@@ -1,0 +1,55 @@
+package model;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NodeTest {
+    Node<String> testNodeA = new Node<>("Node A");
+    Node<String> testNodeB = new Node<>("Node B");
+    Node<String> testNodeC = new Node<>("Node C");
+
+    @BeforeEach
+    void linkTestNodes() {
+        testNodeA.linkNext(testNodeB);
+        testNodeB.linkPrev(testNodeA);
+        testNodeB.linkNext(testNodeC);
+        testNodeC.linkPrev(testNodeB);
+    }
+
+    @Test
+    @DisplayName("Узел A можно взаимно связать с узлом B")
+    void shouldLinkNodes() {
+        assertEquals(testNodeA.next, testNodeB);
+        assertEquals(testNodeB.prev, testNodeA);
+    }
+
+    @Test
+    @DisplayName("При удалении себя узел связывает соседние узлы")
+    void shouldLinkNeighborsUponRemoval() {
+        testNodeB.removeSelf();
+
+        // Удаление узла с соседями в обе стороны
+        assertEquals(testNodeA.next, testNodeC);
+        assertEquals(testNodeC.prev, testNodeA);
+
+        // Удаление узла с соседом только в одну сторону
+        testNodeC.removeSelf();
+        assertNull(testNodeA.next);
+    }
+
+    @Test
+    @DisplayName("Два идентичных узла равны друг другу")
+    void shouldBeEqualIfIdentical() {
+        Node<String> copyOfTestNodeB = new Node<>("Node B");
+        copyOfTestNodeB.linkPrev(testNodeA);
+        copyOfTestNodeB.linkNext(testNodeC);
+
+        // Намеренное использование assertTrue вместо assertEquals,
+        // чтобы проверить метод equals()
+        assertTrue(testNodeB.equals(copyOfTestNodeB));
+        assertNotEquals(testNodeB, testNodeC);
+    }
+}

--- a/test/model/NodeTest.java
+++ b/test/model/NodeTest.java
@@ -1,6 +1,5 @@
 package model;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
@@ -13,10 +12,10 @@ public class NodeTest {
 
     @BeforeEach
     void linkTestNodes() {
-        testNodeA.linkNext(testNodeB);
-        testNodeB.linkPrev(testNodeA);
-        testNodeB.linkNext(testNodeC);
-        testNodeC.linkPrev(testNodeB);
+        testNodeA.next = testNodeB;
+        testNodeB.prev = testNodeA;
+        testNodeB.next = testNodeC;
+        testNodeC.prev = testNodeB;
     }
 
     @Test
@@ -44,8 +43,8 @@ public class NodeTest {
     @DisplayName("Два идентичных узла равны друг другу")
     void shouldBeEqualIfIdentical() {
         Node<String> copyOfTestNodeB = new Node<>("Node B");
-        copyOfTestNodeB.linkPrev(testNodeA);
-        copyOfTestNodeB.linkNext(testNodeC);
+        copyOfTestNodeB.prev = testNodeA;
+        copyOfTestNodeB.next = testNodeC;
 
         // Намеренное использование assertTrue вместо assertEquals,
         // чтобы проверить метод equals()

--- a/test/service/InMemoryHistoryManagerTest.java
+++ b/test/service/InMemoryHistoryManagerTest.java
@@ -23,11 +23,14 @@ public class InMemoryHistoryManagerTest {
     @Test
     @DisplayName("Класс InMemoryHistoryManager корректно добавляет задачи в историю просмотров")
     void shouldAddTasksToHistory() {
+        task.setId(1);
+        epic.setId(2);
+        subTask.setId(3);
         historyManager.addTask(task);
         historyManager.addTask(epic);
         historyManager.addTask(subTask);
 
-        Deque<Task> expectedHistory = new LinkedList<>(List.of(task, epic, subTask));
+        List<Task> expectedHistory = new LinkedList<>(List.of(task, epic, subTask));
         assertEquals(expectedHistory, historyManager.getHistory());
     }
 }

--- a/test/service/InMemoryHistoryManagerTest.java
+++ b/test/service/InMemoryHistoryManagerTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class InMemoryHistoryManagerTest {
     private HistoryManager historyManager;
-    private static final int HISTORY_MAX_SIZE = Managers.getDefaultHistory().getHistoryMaxSize();
 
     private static final Task task = new Task("Задача", "Описание задачи", Status.NEW);
     private static final Epic epic = new Epic("Эпик", "Описание эпика");
@@ -30,32 +29,5 @@ public class InMemoryHistoryManagerTest {
 
         Deque<Task> expectedHistory = new LinkedList<>(List.of(task, epic, subTask));
         assertEquals(expectedHistory, historyManager.getHistory());
-    }
-
-    @Test
-    @DisplayName("Класс InMemoryHistoryManager корректно ограничивает размер истории просмотров задач")
-    void shouldNotOverflowHistorySize() {
-        for (int i = 0; i < HISTORY_MAX_SIZE + 1; i++) {
-            historyManager.addTask(task);
-        }
-        assertEquals(HISTORY_MAX_SIZE, historyManager.getHistory().size());
-    }
-
-    @Test
-    @DisplayName("Класс InMemoryHistoryManager корректно размещает элементы по принципу first in - first out")
-    void shouldFollowFIFOOrder() {
-        historyManager.addTask(subTask);
-        for (int i = 0; i < HISTORY_MAX_SIZE - 2; i++) {
-            historyManager.addTask(task);
-        }
-        historyManager.addTask(epic);
-
-        assertEquals(subTask, historyManager.getHistory().getFirst());
-        assertEquals(epic, historyManager.getHistory().getLast());
-
-        historyManager.addTask(subTask);
-
-        assertEquals(task, historyManager.getHistory().getFirst());
-        assertEquals(subTask, historyManager.getHistory().getLast());
     }
 }

--- a/test/service/InMemoryHistoryManagerTest.java
+++ b/test/service/InMemoryHistoryManagerTest.java
@@ -18,19 +18,61 @@ public class InMemoryHistoryManagerTest {
     @BeforeEach
     void initHistoryManager() {
         historyManager = Managers.getDefaultHistory();
-    }
-
-    @Test
-    @DisplayName("Класс InMemoryHistoryManager корректно добавляет задачи в историю просмотров")
-    void shouldAddTasksToHistory() {
         task.setId(1);
         epic.setId(2);
         subTask.setId(3);
         historyManager.addTask(task);
         historyManager.addTask(epic);
         historyManager.addTask(subTask);
+    }
 
+    @Test
+    @DisplayName("Класс InMemoryHistoryManager корректно добавляет задачи в историю просмотров")
+    void shouldAddTasksToHistory() {
         List<Task> expectedHistory = new LinkedList<>(List.of(task, epic, subTask));
+        assertEquals(expectedHistory, historyManager.getHistory());
+    }
+
+    @Test
+    @DisplayName("Задачи корректно удаляются из истории по ID задачи")
+    void shouldRemoveViewRecordByTaskId() {
+        List<Task> expectedHistory = new ArrayList<>(List.of(task, subTask));
+        historyManager.remove(2);
+
+        assertEquals(expectedHistory, historyManager.getHistory());
+    }
+
+    @Test
+    @DisplayName("История не содержит дубликатов и хранит только самый свежий просмотр задачи")
+    void shouldKeepOnlyUniqueLatestViews() {
+        // Обновление записи из середины истории
+        Task updatedEpic = new Epic("Эпик", "Обновлённое описание эпика");
+        updatedEpic.setId(2);
+        List<Task> expectedHistory = new ArrayList<>(List.of(task, subTask, updatedEpic));
+
+        historyManager.addTask(updatedEpic);
+
+        assertEquals(expectedHistory, historyManager.getHistory());
+
+        // Обновление записи из начала истории (head node)
+        initHistoryManager();
+        Task updatedTask = new Task("Задача", "Описание задачи", Status.DONE);
+        updatedTask.setId(1);
+        expectedHistory = new ArrayList<>(List.of(epic, subTask, updatedTask));
+
+        historyManager.addTask(updatedTask);
+
+        assertEquals(expectedHistory, historyManager.getHistory());
+
+        // Обновление записи из конца истории (tail node)
+        initHistoryManager();
+        Task updatedSubTask = new SubTask("Подзадача", "Описание подзадачи",
+                Status.NEW, 2);
+        updatedSubTask.setId(3);
+        expectedHistory = new ArrayList<>(List.of(task, epic, updatedSubTask));
+
+        historyManager.addTask(updatedSubTask);
+
         assertEquals(expectedHistory, historyManager.getHistory());
     }
 }

--- a/test/service/InMemoryTaskManagerTest.java
+++ b/test/service/InMemoryTaskManagerTest.java
@@ -3,10 +3,13 @@ package service;
 import model.*;
 import org.junit.jupiter.api.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class InMemoryTaskManagerTest {
-    private final TaskManager taskManager = Managers.getDefault();
+    private TaskManager taskManager;
     Task task = new Task("Задача", "Описание задачи", Status.NEW);
     Epic epic = new Epic("Эпик", "Описание эпика");
     SubTask subTask = new SubTask("Подзадача", "Описание подзадачи",
@@ -14,6 +17,7 @@ public class InMemoryTaskManagerTest {
 
     @BeforeEach
     void addTasksOfEachType(){
+        taskManager = Managers.getDefault();
         taskManager.createTask(task);// id=1
         taskManager.createEpic(epic); // id=2
         taskManager.createSubTask(subTask); // id=3, epicId=2
@@ -42,6 +46,18 @@ public class InMemoryTaskManagerTest {
     void shouldDeleteTaskCorrectly(){
         taskManager.removeTaskById(1);
         assertNull(taskManager.getTaskById(1));
+    }
+
+    @Test
+    @DisplayName("Записи о просмотрах удаляются из истории при удалении задачи")
+    void shouldDeleteViewHistoryRecordsCorrectly(){
+        Task task = taskManager.getTaskById(1);
+        List<Task> expectedHistory = new ArrayList<>(List.of(epic, task));
+
+        assertEquals(expectedHistory, taskManager.getHistory());
+
+        taskManager.removeTaskById(1);
+        assertEquals(new ArrayList<Task>(List.of(epic)), taskManager.getHistory());
     }
 
     @Test

--- a/test/service/InMemoryTaskManagerTest.java
+++ b/test/service/InMemoryTaskManagerTest.java
@@ -82,15 +82,22 @@ public class InMemoryTaskManagerTest {
         TaskManager taskManager = Managers.getDefault();
         Task originalTask = new Task("Оригинал", "Описание оригинала", Status.NEW);
 
+        // Добавляем задачу в менеджер и дёргаем get, чтобы она попала в историю
         int addedTaskId = taskManager.createTask(originalTask);
         taskManager.getTaskById(1);
 
+        // Проверяем, что первая (единственная) запись в истории - исходная задача
+        assertEquals(taskManager.getHistory().getFirst(), originalTask);
+
+        // Создаём обновлённую задачу и через updateTask заменяем исходную задачу в менеджере
         Task updatedTask = new Task("Уже не оригинал","Другое описание", Status.IN_PROGRESS);
         taskManager.updateTask(updatedTask, addedTaskId);
 
-        assertEquals(updatedTask ,taskManager.getTaskById(1));
-        assertEquals(taskManager.getHistory().getFirst(), originalTask);
-        assertEquals(taskManager.getHistory().getLast(), updatedTask);
+        // Проверяем, что в менеджере лежит уже обновлённая задача + дёргаем get, чтобы обновить историю
+        assertEquals(updatedTask, taskManager.getTaskById(1));
+
+        // Проверяем, что первая (единственная) запись в истории - обновлённая задача
+        assertEquals(taskManager.getHistory().getFirst(), updatedTask);
     }
 
     @Test


### PR DESCRIPTION
## Что было сделано
Согласно ТЗ финального задания 6-го спринта, в проект были внесены следующие изменения:

- История просмотров задач больше не ограничена по размеру.
- В истории больше не хранятся дубли (разные просмотры одной и той же задачи). Теперь хранится только один самый свежий просмотр для каждой просмотренной задачи.
- Была полностью переработана логика и механизм хранения истории. В новой реализации используется комбинация из двусвязного списка и HashMap. Такой подход позволяет стабильно быстро удалять любые записи из истории просмотров, благодаря асимптотической сложности операции O(1).
- Были добавлены новые, и обновлены существующие Unit-тесты.
- В классе Main было выполнено дополнительное задание на реализацию пользовательского сценария.

## Дополнительная информация:
Одно из заданий ТЗ звучит так: "С помощью сеттеров экземпляры задач позволяют изменить любое своё поле, но это может повлиять на данные внутри менеджера. Протестируйте эти кейсы и подумайте над возможными вариантами решения проблемы."

Моё решение:
- Все сеттеры, кроме `setId(int id)` были удалены, т.к. они не используются, но потенциально дают доступ к изменению внутренних полей задач. Для таких изменений в классе InMemoryTaskManager предусмотрены соответствующие методы обновления задач/эпиков/подзадач.
- Нет сеттеров = нечего тестировать, т.к. без сеттеров изменить приватные поля невозможно, благодаря ограничениям на уровне компилятора Java.
- Единственный сеттер, который используется - это `setId(int id)`. Его необходимо оставить публичным, т.к. это единственный способ обеспечить присвоение каждой задаче уникального ID, который создаёт отдельный класс-генератор. Наличие независимого внешнего генератора ID соответствует принципам разделения ответственности и декомпозиции кода.